### PR TITLE
Fix rename_window checking wrong directory for duplicates

### DIFF
--- a/DnD_Time_Manager.py
+++ b/DnD_Time_Manager.py
@@ -439,7 +439,7 @@ while True:
 
     elif event.endswith("::rename_campaign"):
         window.disable()
-        new_campaign=popup.rename_window(campaign, theme=pref["theme"], par_centre=centre)
+        new_campaign=popup.rename_window(campaign, user_area, theme=pref["theme"], par_centre=centre)
         window.enable()
 
         if new_campaign!=None:

--- a/window_layouts.py
+++ b/window_layouts.py
@@ -268,11 +268,12 @@ def pref_window(pref, db, theme=None, par_centre=(None,None)):
     return pref, save, db
 
 
-def rename_window(old_name, theme=None, par_centre=(None,None)):
+def rename_window(old_name, user_area, theme=None, par_centre=(None,None)):
     """Opens a dialog to rename a campaign.
 
     Args:
         old_name: The current campaign name, displayed in the dialog header.
+        user_area: Path to the user data directory.
         theme: PySimpleGUI theme string to apply.
         par_centre: Parent window centre (x, y) for positioning, or (None, None).
 
@@ -307,11 +308,11 @@ def rename_window(old_name, theme=None, par_centre=(None,None)):
 
         elif event=="Confirm" or focused_enter=="campaign_name":
             name=window["campaign_name"].Get()
-            if name!="" and name not in listdir():
+            if name!="" and name not in listdir(abspath(user_area+"/campaigns")):
                 window.close()
                 return name
             else:
-                if name in listdir():
+                if name in listdir(abspath(user_area+"/campaigns")):
                     window.disable()
                     alert_box(text=f"Campaign \"{name}\" already exists", theme=theme, par_centre=par_centre)
                     window.enable()
@@ -411,16 +412,18 @@ def set_reminder(time_data, pref, theme=None, par_centre=(None,None)):
                d_year=(window["year_input"]).get()
                pref["set_reminder_option"]="time"
 
+               valid=True
                for i in (d_hour,d_day,d_month,d_year):
                    try:
                        _=int(i)
                    except ValueError:
                        alert_box(text="Please enter integer values", theme=theme, par_centre=par_centre)
-                       continue
+                       valid=False
+                       break
 
-
-               d_hour,d_day,d_month,d_year=int(d_hour),int(d_day),int(d_month),int(d_year)
-               hour, day, month, year=time_increment(start_time=(hour, day, month, year), increment=(d_hour,d_day,d_month,d_year))
+               if valid:
+                   d_hour,d_day,d_month,d_year=int(d_hour),int(d_day),int(d_month),int(d_year)
+                   hour, day, month, year=time_increment(start_time=(hour, day, month, year), increment=(d_hour,d_day,d_month,d_year))
 
             window.close()
             return (text, (hour,day,month,year)),pref


### PR DESCRIPTION
rename_window was checking listdir() (current working directory) instead of the campaigns folder. Now correctly passes user_area parameter and checks listdir(abspath(user_area+'/campaigns')) like create_campaign does.